### PR TITLE
Fixes issue #4 and #5

### DIFF
--- a/src/creator-UI.coffee
+++ b/src/creator-UI.coffee
@@ -3,7 +3,9 @@ Namespace('Wordguess').CreatorUI = do ->
 	regexWhitespace        = /\n|\s/
 	regexTwoOrMoreSpaces   = /\s{2,}/g
 	regexNewlineMultiSpace = /\s{2,}|\n/g
-	regexNotAlpha          = /[^A-z]/
+	
+	# Regex to match non-letter characters (non-Unicode letters)
+	regexNotAlpha = /[^\p{L}]/u
 
 	setInputValues = (widgetTitle, paragraph, wordsToSkip) ->
 		document.getElementById('title').value = widgetTitle

--- a/src/creator-UI.coffee
+++ b/src/creator-UI.coffee
@@ -3,7 +3,7 @@ Namespace('Wordguess').CreatorUI = do ->
 	regexWhitespace        = /\n|\s/
 	regexTwoOrMoreSpaces   = /\s{2,}/g
 	regexNewlineMultiSpace = /\s{2,}|\n/g
-	
+
 	# Regex to match non-letter characters (non-Unicode letters)
 	regexNotAlpha = /[^\p{L}]/u
 
@@ -87,6 +87,7 @@ Namespace('Wordguess').CreatorUI = do ->
 		warningText.style.display = 'none'
 
 		return this
+		
 
 	animateInSecondMenu = (editRegion, hiddenWords, options) ->
 		optionsH3  = options.children[0].style

--- a/src/creator-events.coffee
+++ b/src/creator-events.coffee
@@ -175,9 +175,6 @@ Namespace('Wordguess').CreatorEvents = do ->
 				.highlightWords(numWordsToSkip, paragraphTextarea.value, editable)
 
 		manHide.addEventListener 'click', ->
-			console.log 'manHide clicked'
-			console.log 'previousHiddenWords', previousHiddenWords
-			console.log 'hiddenWords', Wordguess.CreatorLogic.getHiddenWords()
 
 			if not animating
 				animating = true

--- a/src/creator-events.coffee
+++ b/src/creator-events.coffee
@@ -29,6 +29,7 @@ Namespace('Wordguess').CreatorEvents = do ->
 	manuallySelectInfo  = null
 
 	warningText = null
+	saveWarningText = null
 
 	infoBubbles = null
 	bigInfo    = null
@@ -73,6 +74,8 @@ Namespace('Wordguess').CreatorEvents = do ->
 		bigInfo    = document.getElementsByClassName('big-info')
 
 		warningText = document.getElementById('warning-text')
+
+		saveWarningText = document.getElementById('save-warning-text')
 
 		return this
 
@@ -356,7 +359,11 @@ Namespace('Wordguess').CreatorEvents = do ->
 			index = parseInt(this.getAttribute('data-index'))
 			Wordguess.CreatorLogic.removeHiddenWord(this, index)
 
+		# adding a word to the hidden words
 		else
+			Wordguess.CreatorUI
+				.hideWarningText(saveWarningText)
+
 			# store the index of the word in the paragraph
 			index = parseInt(this.getAttribute('data-index'))
 

--- a/src/creator-events.coffee
+++ b/src/creator-events.coffee
@@ -103,10 +103,14 @@ Namespace('Wordguess').CreatorEvents = do ->
 
 			else # A paragraph has been entered.
 				menu = 2
-					
+
 				Wordguess.CreatorLogic
 					.resetWordsToSkip(paragraph, numWordsToSkip)
 					.analyzeParagraph(paragraphTextarea.value)
+
+				previousHiddenWords = Wordguess.CreatorLogic
+					.updateHiddenWords(paragraphTextarea.value, previousHiddenWords)
+
 
 				Wordguess.CreatorUI
 					.hideFirstMenu(paragraphTextarea, resetButton)

--- a/src/creator-events.coffee
+++ b/src/creator-events.coffee
@@ -81,6 +81,13 @@ Namespace('Wordguess').CreatorEvents = do ->
 		previousHiddenWords = Wordguess.CreatorLogic.getHiddenWords().slice()
 
 		return this
+
+	initializeWordsToSkip = (wordsToSkip) ->
+		numWordsToSkip.innerHTML = wordsToSkip
+		Wordguess.CreatorLogic
+			.setWordsToSkip(wordsToSkip)
+
+		return this
 	
 	onNextClick = (previousMode) ->
 
@@ -183,9 +190,9 @@ Namespace('Wordguess').CreatorEvents = do ->
 		Wordguess.CreatorLogic
 			.turnOffManualHiding()
 
-		if wordsToSkip is -1
-			wordsToSkip = 3
-			numWordsToSkip.innerHTML = wordsToSkip
+		# if wordsToSkip is -1
+		# 	wordsToSkip = 3
+		# 	numWordsToSkip.innerHTML = wordsToSkip
 
 		options.children[2].style.display = 'block'
 		options.children[3].style.display = 'none'
@@ -393,3 +400,4 @@ Namespace('Wordguess').CreatorEvents = do ->
 	onManHideClick				  : onManHideClick
 	onAutoHideClick				  : onAutoHideClick
 	storeHiddenWords			  : storeHiddenWords
+	initializeWordsToSkip		  : initializeWordsToSkip

--- a/src/creator-events.coffee
+++ b/src/creator-events.coffee
@@ -193,10 +193,6 @@ Namespace('Wordguess').CreatorEvents = do ->
 		Wordguess.CreatorLogic
 			.turnOffManualHiding()
 
-		# if wordsToSkip is -1
-		# 	wordsToSkip = 3
-		# 	numWordsToSkip.innerHTML = wordsToSkip
-
 		options.children[2].style.display = 'block'
 		options.children[3].style.display = 'none'
 

--- a/src/creator-events.coffee
+++ b/src/creator-events.coffee
@@ -35,6 +35,9 @@ Namespace('Wordguess').CreatorEvents = do ->
 	animating    = false
 	menu         = 1
 
+	# Previous state of manual hidden words
+	previousHiddenWords = []
+
 	cacheElements = ->
 		# Divs:
 		editRegion        = document.getElementById('edit-region')
@@ -129,6 +132,11 @@ Namespace('Wordguess').CreatorEvents = do ->
 				else # A paragraph has been entered.
 					menu = 2
 
+					# reset the manually selected words
+					previousHiddenWords = []
+					Wordguess.CreatorLogic
+						.resetHiddenWordsIndices()
+						
 					Wordguess.CreatorLogic
 						.resetWordsToSkip(paragraph, numWordsToSkip)
 						.analyzeParagraph(paragraphTextarea.value)
@@ -180,7 +188,7 @@ Namespace('Wordguess').CreatorEvents = do ->
 				hiddenWordsBox.innerHTML = ''
 
 				Wordguess.CreatorLogic
-					.setUpManualHiding(paragraphTextarea.value, editable)
+					.setUpManualHiding(paragraphTextarea.value, editable, previousHiddenWords)
 				Wordguess.CreatorUI
 					.showHiddenWords(hiddenWordsBox)
 
@@ -204,6 +212,11 @@ Namespace('Wordguess').CreatorEvents = do ->
 
 				this.classList.add 'selected'
 				manHide.classList.remove 'selected'
+
+				if manuallyHide is on
+
+					previousHiddenWords = Wordguess.CreatorLogic.getHiddenWords()
+
 
 				manuallyHide = off
 				Wordguess.CreatorLogic
@@ -294,12 +307,17 @@ Namespace('Wordguess').CreatorEvents = do ->
 	onEditableClick = ->
 		if this.classList.contains 'manually-selected'
 			this.classList.remove 'manually-selected'
-			Wordguess.CreatorLogic.removeHiddenWord(this)
+
+			index = parseInt(this.getAttribute('data-index'))
+			Wordguess.CreatorLogic.removeHiddenWord(this, index)
 
 		else
+			# store the index of the word in the paragraph
+			index = parseInt(this.getAttribute('data-index'))
+
 			this.classList.add 'manually-selected'
 			Wordguess.CreatorLogic
-				.pushHiddenWord(this.innerHTML)
+				.pushHiddenWord(this.innerHTML, index)
 
 		Wordguess.CreatorUI
 			.showHiddenWords(hiddenWordsBox)

--- a/src/creator-events.coffee
+++ b/src/creator-events.coffee
@@ -387,8 +387,6 @@ Namespace('Wordguess').CreatorEvents = do ->
 			edit.removeEventListener 'mouseout', onEditableOut
 			edit.removeEventListener 'click', onEditableClick
 
-	getCurrentMode = ->
-		return mode
 
 	# Public methods.
 	cacheElements                 : cacheElements
@@ -396,7 +394,6 @@ Namespace('Wordguess').CreatorEvents = do ->
 	setSecondMenuEventListeners   : setSecondMenuEventListeners
 	setManualChoiceEventListeners : setManualChoiceEventListeners
 	onNextClick                   : onNextClick
-	getCurrentMode				  : getCurrentMode
 	onManHideClick				  : onManHideClick
 	onAutoHideClick				  : onAutoHideClick
 	storeHiddenWords			  : storeHiddenWords

--- a/src/creator-logic.coffee
+++ b/src/creator-logic.coffee
@@ -148,6 +148,13 @@ Namespace('Wordguess').CreatorLogic = do ->
 
 	buildSaveData = (titleValue) ->
 
+		if manuallyHide is on and hiddenWordsIndices.size is 0
+			saveWarningText = document.getElementById('save-warning-text')
+			console.log saveWarningText
+			Wordguess.CreatorUI.showWarningText(saveWarningText)
+			return
+		
+
 		manualSkippingIndices = Array.from(hiddenWordsIndices)
 
 		previousWordsToSkip = wordsToSkip

--- a/src/creator-logic.coffee
+++ b/src/creator-logic.coffee
@@ -7,20 +7,28 @@ Namespace('Wordguess').CreatorLogic = do ->
 
 	wordsToSkip = 3
 	hiddenWords = []
+	hiddenWordsIndices = new Set()
 	manualSkippingIndices = []
 	manuallyHide = off
 
 	resetHiddenWords = ->
 		hiddenWords = []
 
+	resetHiddenWordsIndices = ->
+		hiddenWordsIndices = new Set()
+
 	getHiddenWords = ->
 		return hiddenWords
 
-	pushHiddenWord = (word) ->
+	pushHiddenWord = (word, index) ->
 		hiddenWords.push(word)
+		hiddenWordsIndices.add(index)
 
 	# Return array of hidden words minus the clicked word.
-	removeHiddenWord = (word) ->
+	removeHiddenWord = (word, index) ->
+
+		hiddenWordsIndices.delete(index)
+
 		text = word.innerHTML
 		for hidden, i in hiddenWords
 			console.log i, hidden
@@ -64,13 +72,23 @@ Namespace('Wordguess').CreatorLogic = do ->
 		cleansedParagraph = cleansedParagraph.replace(regexTwoOrMoreSpaces, ' ').split(regexWhitespace)
 		return cleansedParagraph
 
-	setUpManualHiding = (paragraph, editable) ->
+	setUpManualHiding = (paragraph, editable, previousHiddenWords) ->
 		manuallyHide = on
 		resetHiddenWords()
+
+
+		# show previous hidden words chosen by the user
+		hiddenWords = previousHiddenWords
+
 		paragraph = replaceTags(paragraph.replace(regexTwoOrMoreSpaces, ' ')).split(regexWhitespace)
 
 		for i in [0..paragraph.length - 1]
-			paragraph[i] = "<span>#{paragraph[i]}</span>"
+
+			# make span yellow by default if it was previously chosen
+			if hiddenWordsIndices.has(i)
+				paragraph[i] = "<span data-index='#{i}' class='manually-selected'>#{paragraph[i]}</span>"
+			else
+				paragraph[i] = "<span data-index='#{i}'>#{paragraph[i]}</span>"
 
 		editable.innerHTML = paragraph.join ' '
 
@@ -161,3 +179,4 @@ Namespace('Wordguess').CreatorLogic = do ->
 	analyzeParagraph      : analyzeParagraph
 	setUpManualHiding     : setUpManualHiding
 	turnOffManualHiding   : turnOffManualHiding
+	resetHiddenWordsIndices : resetHiddenWordsIndices

--- a/src/creator-logic.coffee
+++ b/src/creator-logic.coffee
@@ -152,7 +152,7 @@ Namespace('Wordguess').CreatorLogic = do ->
 			saveWarningText = document.getElementById('save-warning-text')
 			console.log saveWarningText
 			Wordguess.CreatorUI.showWarningText(saveWarningText)
-			return
+			return null
 		
 
 		manualSkippingIndices = Array.from(hiddenWordsIndices)

--- a/src/creator-logic.coffee
+++ b/src/creator-logic.coffee
@@ -162,8 +162,22 @@ Namespace('Wordguess').CreatorLogic = do ->
 
 		paragraph = cleanParagraph(paragraph)
 
+		# prepares hidden words for automatic hiding
 		for i in [wordsToSkip..paragraph.length - 1] by (wordsToSkip + 1)
 			hiddenWords.push paragraph[i]
+	
+	updateHiddenWords = (paragraph, previousHiddenWords) ->
+		paragraph = getParagraphChunks(paragraph)
+
+		# update hidden words at the same indices and remove indices out of bounds
+		newHiddenWords = []
+		hiddenWordsIndices.forEach (index) ->
+			if index < paragraph.length
+				newHiddenWords.push(paragraph[index])
+			else
+				hiddenWordsIndices.delete(index)
+		
+		previousHiddenWords = newHiddenWords
 	
 	initializeHiddenWords = (manualSkippingIndices, paragraph) ->
 		hiddenWordsIndices = new Set(manualSkippingIndices)
@@ -198,3 +212,4 @@ Namespace('Wordguess').CreatorLogic = do ->
 	turnOffManualHiding   : turnOffManualHiding
 	resetHiddenWordsIndices : resetHiddenWordsIndices
 	initializeHiddenWords : initializeHiddenWords
+	updateHiddenWords     : updateHiddenWords

--- a/src/creator-logic.coffee
+++ b/src/creator-logic.coffee
@@ -139,14 +139,10 @@ Namespace('Wordguess').CreatorLogic = do ->
 
 	buildSaveData = (titleValue) ->
 		if manuallyHide is on
-			manualSkippingIndices = []
-
-			editables = document.querySelectorAll('#editable span')
-			for edit, i in editables
-				if edit.classList.contains 'manually-selected'
-					manualSkippingIndices.push i
-
 			wordsToSkip = -1
+
+		manualSkippingIndices = Array.from(hiddenWordsIndices)
+
 
 		paragraph = cleanParagraph(document.getElementById('paragraph').value)
 		questionsAnswers = buildQuestionsAnswers(paragraph)

--- a/src/creator-logic.coffee
+++ b/src/creator-logic.coffee
@@ -3,7 +3,9 @@ Namespace('Wordguess').CreatorLogic = do ->
 	regexWhitespace        = /\n|\s/
 	regexTwoOrMoreSpaces   = /\s{2,}/g
 	regexNewlineMultiSpace = /\s{2,}|\n/g
-	regexNotAlpha          = /[^A-z]/
+	
+	# Regex to match non-letter characters (non-Unicode letters)
+	regexNotAlpha = /[^\p{L}]/u
 
 	wordsToSkip = 3
 	hiddenWords = []
@@ -121,7 +123,8 @@ Namespace('Wordguess').CreatorLogic = do ->
 
 	buildQuestionsAnswers = (paragraph) ->
 		questionsAnswers = []
-
+		console.log 'manualSkippingIndices', manualSkippingIndices
+		console.log 'my paragraph', paragraph
 		j = 1
 
 		if manuallyHide is on
@@ -141,6 +144,8 @@ Namespace('Wordguess').CreatorLogic = do ->
 					'questions' :['text': 'word #' + j],
 					'answers'   :['text': removePunc(paragraph[i])]
 				j++
+
+		console.log "my questionsAnswers", questionsAnswers
 
 		return questionsAnswers
 

--- a/src/creator-logic.coffee
+++ b/src/creator-logic.coffee
@@ -36,7 +36,6 @@ Namespace('Wordguess').CreatorLogic = do ->
 
 		text = word.innerHTML
 		for hidden, i in hiddenWords
-			console.log i, hidden
 			if hidden == text
 				hiddenWords.splice i, 1
 				return

--- a/src/creator-logic.coffee
+++ b/src/creator-logic.coffee
@@ -147,12 +147,15 @@ Namespace('Wordguess').CreatorLogic = do ->
 		paragraph = cleanParagraph(document.getElementById('paragraph').value)
 		questionsAnswers = buildQuestionsAnswers(paragraph)
 
+		currentMode = Wordguess.CreatorEvents.getCurrentMode()
+
 		return qset =
 			'questions_answers'     : questionsAnswers
 			'title'                 : replaceTags(document.getElementById('title').value)
 			'paragraph'             : replaceTags(paragraph.join ' ')
 			'wordsToSkip'           : wordsToSkip
 			'manualSkippingIndices' : manualSkippingIndices
+			'mode'				    : currentMode
 
 	analyzeParagraph = (paragraph) ->
 		resetHiddenWords()

--- a/src/creator-logic.coffee
+++ b/src/creator-logic.coffee
@@ -3,7 +3,7 @@ Namespace('Wordguess').CreatorLogic = do ->
 	regexWhitespace        = /\n|\s/
 	regexTwoOrMoreSpaces   = /\s{2,}/g
 	regexNewlineMultiSpace = /\s{2,}|\n/g
-	
+
 	# Regex to match non-letter characters (non-Unicode letters)
 	regexNotAlpha = /[^\p{L}]/u
 
@@ -123,8 +123,6 @@ Namespace('Wordguess').CreatorLogic = do ->
 
 	buildQuestionsAnswers = (paragraph) ->
 		questionsAnswers = []
-		console.log 'manualSkippingIndices', manualSkippingIndices
-		console.log 'my paragraph', paragraph
 		j = 1
 
 		if manuallyHide is on
@@ -145,7 +143,6 @@ Namespace('Wordguess').CreatorLogic = do ->
 					'answers'   :['text': removePunc(paragraph[i])]
 				j++
 
-		console.log "my questionsAnswers", questionsAnswers
 
 		return questionsAnswers
 
@@ -153,11 +150,15 @@ Namespace('Wordguess').CreatorLogic = do ->
 
 		manualSkippingIndices = Array.from(hiddenWordsIndices)
 
+		previousWordsToSkip = wordsToSkip
+
+		if manuallyHide is on
+			wordsToSkip = -1
+
 
 		paragraph = cleanParagraph(document.getElementById('paragraph').value)
 		questionsAnswers = buildQuestionsAnswers(paragraph)
 
-		currentMode = Wordguess.CreatorEvents.getCurrentMode()
 
 		return qset =
 			'questions_answers'     : questionsAnswers
@@ -165,7 +166,7 @@ Namespace('Wordguess').CreatorLogic = do ->
 			'paragraph'             : replaceTags(paragraph.join ' ')
 			'wordsToSkip'           : wordsToSkip
 			'manualSkippingIndices' : manualSkippingIndices
-			'mode'				    : currentMode
+			'previousWordsToSkip'   : previousWordsToSkip
 
 	analyzeParagraph = (paragraph) ->
 		resetHiddenWords()

--- a/src/creator-logic.coffee
+++ b/src/creator-logic.coffee
@@ -11,6 +11,9 @@ Namespace('Wordguess').CreatorLogic = do ->
 	manualSkippingIndices = []
 	manuallyHide = off
 
+	setWordsToSkip = (num) ->
+		wordsToSkip = num
+
 	resetHiddenWords = ->
 		hiddenWords = []
 
@@ -138,8 +141,6 @@ Namespace('Wordguess').CreatorLogic = do ->
 		return questionsAnswers
 
 	buildSaveData = (titleValue) ->
-		if manuallyHide is on
-			wordsToSkip = -1
 
 		manualSkippingIndices = Array.from(hiddenWordsIndices)
 
@@ -170,8 +171,10 @@ Namespace('Wordguess').CreatorLogic = do ->
 		paragraph = getParagraphChunks(paragraph)
 
 		# update hidden words at the same indices and remove indices out of bounds
+		sortedHiddenWordsIndices = Array.from(hiddenWordsIndices).sort()
+
 		newHiddenWords = []
-		hiddenWordsIndices.forEach (index) ->
+		sortedHiddenWordsIndices.forEach (index) ->
 			if index < paragraph.length
 				newHiddenWords.push(paragraph[index])
 			else
@@ -213,3 +216,4 @@ Namespace('Wordguess').CreatorLogic = do ->
 	resetHiddenWordsIndices : resetHiddenWordsIndices
 	initializeHiddenWords : initializeHiddenWords
 	updateHiddenWords     : updateHiddenWords
+	setWordsToSkip        : setWordsToSkip

--- a/src/creator-logic.coffee
+++ b/src/creator-logic.coffee
@@ -104,6 +104,10 @@ Namespace('Wordguess').CreatorLogic = do ->
 		manuallyHide = off
 
 	removePunc = (string) ->
+		# null check
+		if string is undefined
+			return ''
+
 		for i in [0..string.length - 1]
 			first = string.charAt(0)
 			last = string.charAt(string.length - 1)

--- a/src/creator-logic.coffee
+++ b/src/creator-logic.coffee
@@ -150,7 +150,6 @@ Namespace('Wordguess').CreatorLogic = do ->
 
 		if manuallyHide is on and hiddenWordsIndices.size is 0
 			saveWarningText = document.getElementById('save-warning-text')
-			console.log saveWarningText
 			Wordguess.CreatorUI.showWarningText(saveWarningText)
 			return null
 		

--- a/src/creator.coffee
+++ b/src/creator.coffee
@@ -25,13 +25,15 @@ Namespace('Wordguess').Creator = do ->
 		else
 			previousMode = 'automatic'
 
-
+		console.log 'words too skip', wordsToSkip
 		# set default value
 		if wordsToSkip == -1
 
-			if previousWordsToSkip != undefined
+			if previousWordsToSkip != undefined and previousWordsToSkip != -1
+				console.log 'previousWordsToSkip', previousWordsToSkip
 				wordsToSkip = previousWordsToSkip
 			else
+				console.log 'wordsToSkip', wordsToSkip
 				wordsToSkip = 3
 
 

--- a/src/creator.coffee
+++ b/src/creator.coffee
@@ -15,6 +15,8 @@ Namespace('Wordguess').Creator = do ->
 			.setSecondMenuEventListeners()
 
 	initExistingWidget = (title, widget, qset, version, baseUrl) ->
+		previousMode = qset.mode
+
 		wordsToSkip = qset.wordsToSkip
 		if wordsToSkip is -1 then wordsToSkip = 3
 
@@ -30,11 +32,12 @@ Namespace('Wordguess').Creator = do ->
 		Wordguess.CreatorLogic
 			.initializeHiddenWords(manualSkippingIndices, qset.paragraph)
 		
+		Wordguess.CreatorEvents
+			.storeHiddenWords()
 
 		# set screen to state after clicking next
 		Wordguess.CreatorEvents
-			.onNextClick()
-
+			.onNextClick(previousMode)
 
 	onSaveClicked = (mode = 'save') ->
 		titleValue = document.getElementById('title').value

--- a/src/creator.coffee
+++ b/src/creator.coffee
@@ -18,7 +18,6 @@ Namespace('Wordguess').Creator = do ->
 		previousMode = qset.mode
 
 		wordsToSkip = qset.wordsToSkip
-		if wordsToSkip is -1 then wordsToSkip = 3
 
 		manualSkippingIndices = qset.manualSkippingIndices
 
@@ -26,6 +25,7 @@ Namespace('Wordguess').Creator = do ->
 			.cacheElements()
 			.setEventListeners(isMobile)
 			.setSecondMenuEventListeners()
+			.initializeWordsToSkip(wordsToSkip)
 		Wordguess.CreatorUI
 			.setInputValues(title, qset.paragraph, wordsToSkip)
 

--- a/src/creator.coffee
+++ b/src/creator.coffee
@@ -16,24 +16,21 @@ Namespace('Wordguess').Creator = do ->
 
 	initExistingWidget = (title, widget, qset, version, baseUrl) ->
 		wordsToSkip = qset.wordsToSkip
-		previousWordsToSkip = qset.previousWordsToSkip
-		previousMode = undefined
+		previousWordsToSkip = if qset.previousWordsToSkip? then qset.previousWordsToSkip else -1
 
 		# figure out if what was the previously selected mode
+		previousMode = undefined
 		if wordsToSkip == -1
 			previousMode = 'manual'
 		else
 			previousMode = 'automatic'
 
-		console.log 'words too skip', wordsToSkip
 		# set default value
 		if wordsToSkip == -1
 
-			if previousWordsToSkip != undefined and previousWordsToSkip != -1
-				console.log 'previousWordsToSkip', previousWordsToSkip
+			if previousWordsToSkip != -1
 				wordsToSkip = previousWordsToSkip
 			else
-				console.log 'wordsToSkip', wordsToSkip
 				wordsToSkip = 3
 
 
@@ -65,7 +62,7 @@ Namespace('Wordguess').Creator = do ->
 		_qset = Wordguess.CreatorLogic.buildSaveData()
 
 		if _qset == null then return false
-		
+
 		Materia.CreatorCore.save widgetTitle, _qset
 
 	onSaveComplete = (title, widget, qset, version) -> true

--- a/src/creator.coffee
+++ b/src/creator.coffee
@@ -61,6 +61,9 @@ Namespace('Wordguess').Creator = do ->
 		else widgetTitle = 'New Wordguess Widget'
 
 		_qset = Wordguess.CreatorLogic.buildSaveData()
+
+		if _qset == null then return false
+		
 		Materia.CreatorCore.save widgetTitle, _qset
 
 	onSaveComplete = (title, widget, qset, version) -> true

--- a/src/creator.coffee
+++ b/src/creator.coffee
@@ -15,9 +15,25 @@ Namespace('Wordguess').Creator = do ->
 			.setSecondMenuEventListeners()
 
 	initExistingWidget = (title, widget, qset, version, baseUrl) ->
-		previousMode = qset.mode
-
 		wordsToSkip = qset.wordsToSkip
+		previousWordsToSkip = qset.previousWordsToSkip
+		previousMode = undefined
+
+		# figure out if what was the previously selected mode
+		if wordsToSkip == -1
+			previousMode = 'manual'
+		else
+			previousMode = 'automatic'
+
+
+		# set default value
+		if wordsToSkip == -1
+
+			if previousWordsToSkip != undefined
+				wordsToSkip = previousWordsToSkip
+			else
+				wordsToSkip = 3
+
 
 		manualSkippingIndices = qset.manualSkippingIndices
 

--- a/src/creator.html
+++ b/src/creator.html
@@ -65,8 +65,10 @@
 				</div>
 
 
-				<span id = "warning-text">Note: Please finish typing your paragraph before choosing what words to hide. Adding or removing words may affect the list of hidden words
+				<span class = "warning-text" id = "warning-text">Note: Please finish typing your paragraph before choosing what words to hide. Adding or removing words may affect the list of hidden words
 				</span>
+
+				<span class = "warning-text" id = "save-warning-text">Please select at least one word to hide.</span>
 
 				<div id = "paragraph-buttons">
 

--- a/src/creator.scss
+++ b/src/creator.scss
@@ -131,6 +131,7 @@ body {
 
 		#warning-text {
 			color: #eed202;
+			display: none;
 		}
 
 		#paragraph-buttons {

--- a/src/creator.scss
+++ b/src/creator.scss
@@ -129,7 +129,7 @@ body {
 		bottom: 0;
 		width: 900px;
 
-		#warning-text {
+		.warning-text {
 			color: #eed202;
 			display: none;
 		}

--- a/src/player-logic.coffee
+++ b/src/player-logic.coffee
@@ -1,5 +1,7 @@
 Namespace('Wordguess').Logic = do ->
-	regexNotAlpha = /[^A-z]/
+
+	# Regex to match non-letter characters (non-Unicode letters)
+	regexNotAlpha = /[^\p{L}]/u
 
 	# Sends back an input with leading/trailing punctuation.
 	replaceText = (text) ->


### PR DESCRIPTION
**What?**
To address issue #4, I fixed the regex not hiding certain characters properly on the player side. For example, "é" in "Qué" before would be displayed to the user when it should be hidden

To address issue #5, I made it so that returning back to a saved game and switching between automatic and manual saves the words that the user chose to have hidden.

**How?**
To fix issue #4, I noticed that there's a function on the player side that reveals the first and/or the last character of a string depending on if that last/first character is a non-latin character. So, "Done!" would appear as "____!", but non-latin letters should also be hidden. To do this, I changed the `notAlphaRegex` regex to match any unix characters not under the category of letters.

To fix issue #5, I noticed that the current game only maintains an array, `hiddenWords`, to store and display the chosen hidden words across different modes ("manual" and "automatic"), but when switching from manual to automatic, `hiddenWords` changes to store the hidden words for automatic and _forgets_ the content of the array from manual. So, I created a temporary array, `previousHiddenWords`, to store the contents of `hiddenWords` when switching to automatic and populate `hiddenWords` with `previousHiddenWords` when the user switches back to manual. I also have a set that holds the indices of all `previousHiddenWords`. Whenever the user saves draft, the indices of the words get saved. When the user opens up the same game, i store the indices to my set and grab all the associated words at those indices. This method can result in an error refrencing the intended chosen hidden words if the user edits the pargraph, so I created a warning label in the edit paragraph page.

**Why?**
- Fixes #4
- Fixes #5