### PR TITLE
#6 Disables viewing other recorded responses at scorescreen by default. Adds UI to optionally enable it. 

### DIFF
--- a/src/_score/score_module.php
+++ b/src/_score/score_module.php
@@ -37,9 +37,12 @@ class Score_Modules_Wordguess extends Score_Module
 		}
 
 		$final_words = [];
-		if(!$this->qset->data->options->showAllOtherAnswersBoolean)
+		//If options boolean is false it will show no feedback for other recorded responses
+		if ( isset($this->inst->qset->data['options']) &&
+				isset($this->inst->qset->data['options']['showAllOtherAnswersBoolean']) &&
+				$this->inst->qset->data['options']['showAllOtherAnswersBoolean'] === false)
 		{
-			return ''
+			return;
 		}
 		if ( ! empty($all_words))
 		{

--- a/src/_score/score_module.php
+++ b/src/_score/score_module.php
@@ -11,6 +11,7 @@ class Score_Modules_Wordguess extends Score_Module
 	}
 
 	// use the question feedback area to display all guesses for the given word by all students
+	// hide the option when qset.data.options.showAllOtherAnswersBoolean is false(default)
 	protected function get_feedback($log, $answers)
 	{
 		$all_words = [];
@@ -36,6 +37,10 @@ class Score_Modules_Wordguess extends Score_Module
 		}
 
 		$final_words = [];
+		if(!$this->qset->data->options->showAllOtherAnswersBoolean)
+		{
+			return ''
+		}
 		if ( ! empty($all_words))
 		{
 			//second loop - condense words and their counts into single strings

--- a/src/creator-UI.coffee
+++ b/src/creator-UI.coffee
@@ -46,7 +46,7 @@ Namespace('Wordguess').CreatorUI = do ->
 
 	showFirstMenu = (paragraphTextarea, resetButton) ->
 		paragraphTextarea.style.display = 'block'
-		resetButton.style.display = 'block'
+		resetButton.style.display = 'inline-block'
 		resetButton.style.opacity = 1
 
 		return this

--- a/src/creator-events.coffee
+++ b/src/creator-events.coffee
@@ -15,6 +15,9 @@ Namespace('Wordguess').CreatorEvents = do ->
 	nextButton     = null
 	backButton     = null
 	resetButton    = null
+	showAllResponsesDiv = null
+	showAllResponsesInput = null
+	showAllResponsesLabel = null
 	autoHide       = null
 	manHide        = null
 
@@ -49,6 +52,9 @@ Namespace('Wordguess').CreatorEvents = do ->
 		numDown        = document.getElementById('num-down')
 		numWordsToSkip = document.getElementById('num-words-to-skip')
 		nextButton     = document.getElementById('next')
+		showAllResponsesDiv = document.getElementById('showAllResponsesDiv')
+		showAllResponsesInput = document.getElementById('showAllResponsesInput')
+		showAllResponsesLabel = document.getElementById('showAllResponsesLabel')
 		backButton     = document.getElementById('back')
 		resetButton    = document.getElementById('reset')
 		autoHide       = document.getElementById('auto-hide')
@@ -109,6 +115,16 @@ Namespace('Wordguess').CreatorEvents = do ->
 					.setUpManualHiding(paragraph, editable)
 					.showHiddenWords(hiddenWordsBox)
 
+
+		showAllResponsesDiv.addEventListener 'click', ->
+			showAllResponsesInput.checked = !showAllResponsesInput.checked
+			if showAllResponsesInput.checked
+				showAllResponsesDiv.style.backgroundColor = 'lightgreen'
+				showAllResponsesLabel.textContent = 'Show All Responses:Off'
+			else
+				showAllResponsesDiv.style.backgroundColor = '#2E2E2E'
+				showAllResponsesLabel.textContent = 'Show All Responses:On'
+
 		nextButton.addEventListener 'click', ->
 			if not animating
 				animating = true
@@ -141,6 +157,7 @@ Namespace('Wordguess').CreatorEvents = do ->
 						.highlightWords(numWordsToSkip, paragraphTextarea.value, editable)
 
 		return this
+
 
 	setSecondMenuEventListeners = ->
 		numUp.addEventListener 'click', ->

--- a/src/creator-events.coffee
+++ b/src/creator-events.coffee
@@ -119,11 +119,11 @@ Namespace('Wordguess').CreatorEvents = do ->
 		showAllResponsesDiv.addEventListener 'click', ->
 			showAllResponsesInput.checked = !showAllResponsesInput.checked
 			if showAllResponsesInput.checked
-				showAllResponsesDiv.style.backgroundColor = 'lightgreen'
-				showAllResponsesLabel.textContent = 'Show All Responses:Off'
+				showAllResponsesDiv.style.backgroundColor = '#004f00' #dark green
+				showAllResponsesLabel.textContent = 'Show All Responses:On'
 			else
 				showAllResponsesDiv.style.backgroundColor = '#2E2E2E'
-				showAllResponsesLabel.textContent = 'Show All Responses:On'
+				showAllResponsesLabel.textContent = 'Show All Responses:Off'
 
 		nextButton.addEventListener 'click', ->
 			if not animating

--- a/src/creator-logic.coffee
+++ b/src/creator-logic.coffee
@@ -116,7 +116,7 @@ Namespace('Wordguess').CreatorLogic = do ->
 
 		return questionsAnswers
 
-	buildSaveData = (titleValue) ->
+	buildSaveData = ( showAllOtherAnswersBoolean) ->
 		if manuallyHide is on
 			manualSkippingIndices = []
 
@@ -136,6 +136,8 @@ Namespace('Wordguess').CreatorLogic = do ->
 			'paragraph'             : replaceTags(paragraph.join ' ')
 			'wordsToSkip'           : wordsToSkip
 			'manualSkippingIndices' : manualSkippingIndices
+			'options':
+				'showAllOtherAnswersBoolean'   : showAllOtherAnswersBoolean
 
 	analyzeParagraph = (paragraph) ->
 		resetHiddenWords()

--- a/src/creator.coffee
+++ b/src/creator.coffee
@@ -27,10 +27,12 @@ Namespace('Wordguess').Creator = do ->
 
 	onSaveClicked = (mode = 'save') ->
 		titleValue = document.getElementById('title').value
+		showAllOtherAnswersBoolean = document.getElementById('showAllResponsesInput').checked
 		if titleValue then widgetTitle = Wordguess.CreatorLogic.replaceTags(titleValue)
 		else widgetTitle = 'New Wordguess Widget'
 
-		_qset = Wordguess.CreatorLogic.buildSaveData()
+		_qset = Wordguess.CreatorLogic.buildSaveData(showAllOtherAnswersBoolean)
+		console.log _qset
 		Materia.CreatorCore.save widgetTitle, _qset
 
 	onSaveComplete = (title, widget, qset, version) -> true

--- a/src/creator.coffee
+++ b/src/creator.coffee
@@ -32,7 +32,6 @@ Namespace('Wordguess').Creator = do ->
 		else widgetTitle = 'New Wordguess Widget'
 
 		_qset = Wordguess.CreatorLogic.buildSaveData(showAllOtherAnswersBoolean)
-		console.log _qset
 		Materia.CreatorCore.save widgetTitle, _qset
 
 	onSaveComplete = (title, widget, qset, version) -> true

--- a/src/creator.html
+++ b/src/creator.html
@@ -65,9 +65,15 @@
 				</div>
 
 				<!-- buttons -->
-				<div id="next" class="button">Next</div>
-				<div id="back" class="button">Edit Paragraph</div>
-				<div id="reset" class="button">Reset</div>
+				<div class="flex">
+					<div id="next" class="button">Next</div>
+					<div id="back" class="button">Edit Paragraph</div>
+					<div id="reset" class="button">Reset</div>
+					<div id="showAllResponsesDiv" class="button">
+						<label id="showAllResponsesLabel" class="noselect" for="showAllResponses">Show All Responses:Off</label>
+						<input type="checkbox" id="showAllResponsesInput">
+					</div>
+				</div>
 
 			</section> <!-- edit-region -->
 

--- a/src/creator.html
+++ b/src/creator.html
@@ -73,6 +73,10 @@
 						<label id="showAllResponsesLabel" class="noselect" for="showAllResponses">Show All Responses:Off</label>
 						<input type="checkbox" id="showAllResponsesInput">
 					</div>
+					<div class="tooltip">
+						?
+						<span class="tooltiptext">This determines whether or not a player will be able to see all other recorded responses in the scorescreen </span>
+					</div>
 				</div>
 
 			</section> <!-- edit-region -->

--- a/src/creator.scss
+++ b/src/creator.scss
@@ -392,12 +392,16 @@ body {
 	.tooltip {
 		position: relative;
 		display: inline-block;
-		background-color: #38607a;
-		color: #c1ccd3;
-		border-radius: 50%;
-		padding: 3.5px 10px;
+		background-color: #467899;
+		color: #fff;
+		border-radius: 100%;
+		padding: 1.5px 8.5px;
 		text-align: center;
 		cursor: pointer;
+		opacity: 0.6;
+		&:hover {
+			opacity: 1;
+		}
 
 		&:hover .tooltiptext {
 			visibility: visible;
@@ -422,6 +426,16 @@ body {
 			transform: translateX(-50%);
 			transition: opacity 0.3s;
 			white-space: nowrap;
+		}
+		.tooltiptext::after {
+			content: "";
+			position: absolute;
+			top: 100%;
+			left: 50%;
+			margin-left: -5px;
+			border-width: 5px;
+			border-style: solid;
+			border-color: black transparent transparent transparent;
 		}
 	}
 }

--- a/src/creator.scss
+++ b/src/creator.scss
@@ -171,7 +171,7 @@ body {
 		.button {
 			cursor: pointer;
 			font-size: 14px;
-			position: absolute;
+			// position: absolute;
 			text-align: center;
 			width: 70px;
 			display: inline;
@@ -179,20 +179,28 @@ body {
 			background-color: #2E2E2E;
 			color: white;
 			border-radius: 10px;
-			border-bottom: 3px solid #252525;
+			// border-bottom: 3px solid #252525;
 			transition: 0.1s;
 			&:hover {
 				background-color: #484848;
 				border-bottom-color: #3B3B3B;
 				transition: 0.1s;
 			}
+			#showAllResponsesInput {
+				width: 1px;
+				clip: rect(0 0 0 0);
+				position: absolute;
+			}
+		}
+		#showAllResponsesDiv.button {
+			width:152px;
 		}
 		#next.button  {
 
 		}
-		#reset.button {
-			margin-left: 100px;
-		}
+		// #reset.button {
+		// 	margin-left: 100px;
+		// }
 		#back.button  {
 			width: 100px;
 			display: none;
@@ -376,6 +384,11 @@ body {
 			}
 		}
 	}
+	.flex {
+		display: flex;
+		align-items: center;
+		gap:5px;
+	}
 }
 
 /* CSS3 Transitions */
@@ -398,3 +411,15 @@ body {
 	transition: all 300ms cubic-bezier(0.520, -0.430, 0.405, 1.350);
 	transition-timing-function: cubic-bezier(0.520, -0.430, 0.405, 1.350);
 }
+
+.noselect {
+	cursor:pointer;
+	-webkit-touch-callout: none; /* iOS Safari */
+	-webkit-user-select: none; /* Safari */
+	-khtml-user-select: none; /* Konqueror HTML */
+	-moz-user-select: none; /* Old versions of Firefox */
+	-ms-user-select: none; /* Internet Explorer/Edge */
+	user-select: none; /* Non-prefixed version, currently
+								  supported by Chrome, Edge, Opera and Firefox */
+}
+

--- a/src/creator.scss
+++ b/src/creator.scss
@@ -389,6 +389,41 @@ body {
 		align-items: center;
 		gap:5px;
 	}
+	.tooltip {
+		position: relative;
+		display: inline-block;
+		background-color: #38607a;
+		color: #c1ccd3;
+		border-radius: 50%;
+		padding: 3.5px 10px;
+		text-align: center;
+		cursor: pointer;
+
+		&:hover .tooltiptext {
+			visibility: visible;
+			opacity: 0.85;
+			padding: 5px 15px 5px 15px;
+			font-size: 14px;
+
+		}
+
+		.tooltiptext {
+			visibility: hidden;
+			opacity: 0;
+			background-color: black;
+			color: white;
+			text-align: center;
+			border-radius: 5px;
+			padding: 5px;
+			position: absolute;
+			z-index: 1;
+			bottom: 125%;
+			left: 50%;
+			transform: translateX(-50%);
+			transition: opacity 0.3s;
+			white-space: nowrap;
+		}
+	}
 }
 
 /* CSS3 Transitions */

--- a/src/demo.json
+++ b/src/demo.json
@@ -492,7 +492,7 @@
       ],
 
       "options": {
-         "showAllOtherAnswersBoolean": true,
+         "showAllOtherAnswersBoolean": true
       }
     }
   }

--- a/src/demo.json
+++ b/src/demo.json
@@ -489,7 +489,11 @@
         184,
         192,
         195
-      ]
+      ],
+
+      "options": {
+         "showAllOtherAnswersBoolean": true,
+      }
     }
   }
 }


### PR DESCRIPTION
This PR mainly addresses issue #6 adding a toggle button in the creator(disabled by default) to enable the viewing the viewing of other recorded responses at the scorescreen. 

This PR has some changes to the creator HTML and SCSS with the use of flex-box and modern web practices, but it does not fix everything existing in the widget. There are still some old outdated HTML4 tags like center which may need to be addressed to fix tool-tips going out of bounds. Additionally it would be easier to make more additions to the front-end if it was redesigned with better practices like flex-box and div nesting instead of absolute positioning for a lot of things, but that feels more appropriate for a separate issue. 

This PR adds an options object to the qset which stores a boolean value on whether or not to get feedback of all other recorded responses. It does not break existing widgets that do not have this options object in my testing. 